### PR TITLE
add blockresize case with b/gb/mb unit disk

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockresize.cfg
+++ b/libvirt/tests/cfg/backingchain/blockresize.cfg
@@ -1,0 +1,20 @@
+- backingchain.blockresize:
+    type = blockresize
+    start_vm = 'yes'
+    status_error = 'no'
+    variants:
+        - normal_test:
+            status_error = "no"
+            variants:
+                - raw_image:
+                    driver_type = 'raw'
+                    variants:
+                        - size_g:
+                            case_name = 'raw_disk_blockresize'
+                            new_size = '15g'
+                        - size_b:
+                            case_name = 'raw_disk_blockresize'
+                            new_size = '1024b'
+                        - size_mb:
+                            case_name = 'raw_disk_blockresize'
+                            new_size = '1024m'

--- a/libvirt/tests/src/backingchain/blockresize.py
+++ b/libvirt/tests/src/backingchain/blockresize.py
@@ -1,0 +1,94 @@
+import logging
+import os
+
+from avocado.utils import process
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+
+
+def run(test, params, env):
+    """
+    Test blockresize for raw type device which has backing chain element.
+
+    1) Prepare an running guest which has a raw image.
+    2) Resize the block device using GB and KB.
+    3) Check size.
+    """
+
+    def setup_raw_disk_blockresize():
+        """
+        Prepare raw disk and create snapshots.
+        """
+        # Create raw type image
+        image_path, device = test_obj.tmp_dir + '/blockresize_test', 'vdd'
+        cmd = "qemu-img create -f %s %s %s" % ('raw', image_path,
+                                               '500K')
+        process.run(cmd, allow_output_check='combined', shell=True)
+        test_obj.new_image_path = image_path
+        # attach new disk
+        virsh.attach_disk(vm.name, source=image_path, target=device,
+                          extra=" --subdriver %s" % "raw", debug=True)
+        test_obj.new_dev = device
+        # create snap chain
+        test_obj.prepare_snapshot()
+
+    def test_raw_disk_blockresize():
+        """
+        Do blockresize for device which has backing chain element
+        """
+        new_size = params.get('new_size')
+        result = virsh.blockresize(vm_name, test_obj.snap_path_list[-1],
+                                   new_size, debug=True)
+        libvirt.check_exit_status(result)
+        check_obj.check_image_size(test_obj.snap_path_list[-1])
+
+    def teardown_raw_disk_blockresize():
+        """
+        Clean env and resize with origin size.
+        """
+        # clean new disk file
+        logging.info('Start cleaning up.')
+        for ss in test_obj.snap_name_list:
+            virsh.snapshot_delete(vm_name, '%s --metadata' % ss, debug=True)
+        for sp in test_obj.snap_path_list:
+            process.run('rm -rf %s' % sp)
+        # clean first disk snap file
+        image_path = os.path.dirname(original_disk_source)
+        for sf in os.listdir(image_path):
+            if 'snap' in sf:
+                process.run('rm -rf %s/%s' % (image_path, sf))
+        # detach disk
+        virsh.detach_disk(vm_name, target=test_obj.new_dev, debug=True)
+        process.run('rm -rf %s' % test_obj.new_image_path)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    case_name = params.get('case_name', '')
+    # Get vm xml
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    original_disk_source = libvirt_disk.get_first_disk_source(vm)
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+
+    # MAIN TEST CODE ###
+    run_test = eval("test_%s" % case_name)
+    setup_test = eval("setup_%s" % case_name)
+    teardown_test = eval("teardown_%s" % case_name)
+
+    try:
+        # Execute test
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()
+        bkxml.sync()

--- a/provider/backingchain/check_functions.py
+++ b/provider/backingchain/check_functions.py
@@ -2,6 +2,7 @@ import logging
 import re
 
 from avocado.utils import process
+from virttest import utils_misc
 from virttest import libvirt_storage
 
 LOG = logging.getLogger('avocado.backingchain.checkfunction')
@@ -113,3 +114,79 @@ class Checkfunction(object):
             self.test.fail('qemu-img info output of backing chain '
                            'is not correct: %s' % img_info)
         return exist
+
+    def check_image_size(self, image_path):
+        """
+        Check image size with qemu-img command.
+        :param image_path: the path of image.
+        """
+        resize_value = self.params.get('new_size')
+        image_format = self.params.get('driver_type')
+
+        # Format expected image size
+        # Although kb should not be used, libvirt/virsh will accept it and
+        # consider it as a 1000 bytes, which caused issues for qed & qcow2
+        # since they expect a value evenly divisible by 512 (hence bz 1002813).
+        expected_size = 0
+        if "kb" in resize_value:
+            value = int(resize_value[:-2])
+            if image_format in ["qed", "qcow2"]:
+                # qcow2 and qed want a VIR_ROUND_UP value based on 512 byte
+                # sectors - hence this less than visually appealing formula
+                expected_size = (((value * 1000) + 512 - 1) // 512) * 512
+            else:
+                # Raw images...
+                # Ugh - there's some rather ugly looking math when kb
+                # (or mb, gb, tb, etc.) are used as the scale for the
+                # value to create an image. The blockresize for the
+                # running VM uses a qemu json call which differs from
+                # qemu-img would do - resulting in (to say the least)
+                # awkward sizes. We'll just have to make sure we don't
+                # deviates more than a sector.
+                expected_size = value * 1000
+        elif "kib" in resize_value:
+            value = int(resize_value[:-3])
+            expected_size = value * 1024
+        elif resize_value[-1] in "b":
+            expected_size = int(resize_value[:-1])
+        elif resize_value[-1] in "k":
+            value = int(resize_value[:-1])
+            expected_size = value * 1024
+        elif resize_value[-1] == "m":
+            value = int(resize_value[:-1])
+            expected_size = value * 1024 * 1024
+        elif resize_value[-1] == "g":
+            value = int(resize_value[:-1])
+            expected_size = value * 1024 * 1024 * 1024
+            cmd = "qemu-img info %s" % image_path
+            if libvirt_storage.check_qemu_image_lock_support():
+                cmd += " -U"
+            ret = process.run(cmd, allow_output_check='combined', shell=True)
+            status, output = (ret.exit_status, ret.stdout_text.strip())
+            value_return_by_qemu_img = re.search \
+                (r'virtual size:\s+(\d+(\.\d+)?)+\s?G', output).group(1)
+            if value != int(float(value_return_by_qemu_img)):
+                self.test.fail("initial image size in config is not "
+                               "equals to value returned by qemu-img info")
+        else:
+            self.test.error("Unknown scale value")
+
+        # Get current image size
+        image_info = utils_misc.get_image_info(image_path)
+        actual_size = int(image_info['vsize'])
+
+        LOG.info("The expected block size is %s bytes, "
+                 "the actual block size is %s bytes",
+                 expected_size, actual_size)
+
+        # Check the expected size and actualsize
+        # See comment above regarding Raw images
+        if image_format == "raw" and resize_value[-2] in "kb":
+            if abs(int(actual_size) - int(expected_size)) > 512:
+                self.test.fail("New raw blocksize set by blockresize do "
+                               "not match the expected value")
+        else:
+            if int(actual_size) != int(expected_size):
+                self.test.fail("New blocksize set by blockresize is "
+                               "different from actual size from "
+                               "'qemu-img info'")


### PR DESCRIPTION
Add case for blockresize with g , b ,mb unit disk size
test number : RHEL-133310

Signed-off-by: nanli [nanli@redhat.com](mailto:nanli@redhat.com)

Test result :
[root@nanli tp-libvirt]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockresize.normal_test.raw_image.size_mb --vt-connect-uri qemu:///system
JOB ID : 6f11f9b05555680ee58a118524423a5a5dd22fa6
JOB LOG : /root/avocado/job-results/job-2022-02-12T18.19-6f11f9b/job.log
(1/1) type_specific.io-github-autotest-libvirt.backingchain.blockresize.normal_test.raw_image.size_mb: PASS (9.82 s)
RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME : 13.26 s
[root@nanli tp-libvirt]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockresize.normal_test.raw_image.size_g --vt-connect-uri qemu:///system
JOB ID : 73d3fb9d83ccfa9c42ade89086205618d63c0791
JOB LOG : /root/avocado/job-results/job-2022-02-12T18.20-73d3fb9/job.log
(1/1) type_specific.io-github-autotest-libvirt.backingchain.blockresize.normal_test.raw_image.size_g: PASS (9.93 s)
RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME : 13.30 s
[root@nanli tp-libvirt]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockresize.normal_test.raw_image.size_b --vt-connect-uri qemu:///system
JOB ID : 62ae322ae6812dff2983d9aa015d94c1edb64fae
JOB LOG : /root/avocado/job-results/job-2022-02-12T18.20-62ae322/job.log
(1/1) type_specific.io-github-autotest-libvirt.backingchain.blockresize.normal_test.raw_image.size_b: PASS (10.06 s)
RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME : 13.45 s
[root@nanli tp-libvirt]#